### PR TITLE
Add factories to get the tests running

### DIFF
--- a/package.js
+++ b/package.js
@@ -134,6 +134,7 @@ Package.onTest(function (api) {
   api.use("velocity:console-reporter@0.1.4");
   api.use("reactioncommerce:core@0.9.3");
   api.use("reactioncommerce:reaction-accounts");
+  api.use("reactioncommerce:reaction-factories");
 
   api.addFiles("common/factories/accounts.js");
   api.addFiles("tests/jasmine/client/integration/login.js", "client");


### PR DESCRIPTION
The `faker` object is currently not defined because it's been moved to `reaction-factories`. This PR is needed to restore the build (see reactioncommerce/reaction#504).